### PR TITLE
fix(websocket): snapshot session_state to clients on WS connect

### DIFF
--- a/src/reacher/api/routers/proxy.py
+++ b/src/reacher/api/routers/proxy.py
@@ -75,7 +75,11 @@ async def ws_relay(ws: WebSocket, device_id: str, session_id: str):
     # a real WS error to the browser (code 1011) so reconnectAttempt accumulates
     # and the client's give-up logic fires instead of looping silently forever.
     try:
-        upstream = await websockets.connect(upstream_url, open_timeout=10)
+        # ping_interval=None: rely on uvicorn's server-side keepalive on the Pi
+        # rather than running a second, independent library-level ping on the
+        # relay's upstream socket — the two ping layers can race and silently
+        # tear down the upstream under load (Fix #15, secondary hardening).
+        upstream = await websockets.connect(upstream_url, open_timeout=10, ping_interval=None)
     except Exception as exc:
         logger.error(
             "WS relay upstream connect failed for %s/%s url=%s: %s",

--- a/src/reacher/api/routers/websocket.py
+++ b/src/reacher/api/routers/websocket.py
@@ -227,6 +227,14 @@ async def _broadcast_worker():
             session_id = msg.get("session_id", "")
             payload = json.dumps(msg)
 
+            # Fix #15 (diagnostic): a fanout with 0 subscribers means the event
+            # is dropped on the floor — the signature of the proxy late-connect
+            # race. Gated behind DEBUG so it is silent in normal operation.
+            logger.debug(
+                "WS fanout sid=%s type=%s subscribers=%d",
+                session_id, msg.get("type"), len(_connections.get(session_id, set())),
+            )
+
             dead: Set[WebSocket] = set()
             for ws in _connections.get(session_id, set()):
                 try:
@@ -349,6 +357,26 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
     if _orphan_task is None or _orphan_task.done():
         _orphan_task = asyncio.get_running_loop().create_task(_orphan_cleanup())
     logger.info("WebSocket connected for session %s", session_id)
+
+    # Fix #15: snapshot the current session state to this just-connected client.
+    # State transitions (idle->uploading->connected->running) are broadcast as
+    # they happen; a client that connects *after* a transition never sees it. In
+    # proxy/IoT mode the WS relay always connects late (after an async ws-token
+    # fetch), so the Pi fans those transitions to an empty client set and the
+    # browser session stays "idle" — pushEvent then silently drops every event.
+    # Replaying the live state on connect lets any client (relay, direct browser,
+    # or a reconnect) immediately learn the real state.
+    try:
+        sm = websocket.app.state.session_manager
+        info = sm._sessions.get(session_id)
+        if info is not None:
+            await websocket.send_text(json.dumps({
+                "type": "session_state",
+                "session_id": session_id,
+                "data": {"state": info.state},
+            }))
+    except Exception:
+        logger.debug("session_state snapshot on connect failed for %s", session_id, exc_info=True)
 
     try:
         while True:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -212,3 +212,59 @@ class TestBehaviorSinceEndpoint:
         body = resp.json()
         assert len(body["data"]) == 0
         assert body["total"] == 1
+
+
+class TestSessionStateSnapshotOnConnect:
+    """Fix #15: a client connecting to /ws/{sid} immediately receives the current
+    session_state, so a late-connecting proxy relay learns that the session is
+    already running instead of staying stuck at the browser's default 'idle'.
+    """
+
+    @pytest.fixture
+    def api_client(self):
+        with patch("reacher.session_manager.REACHER") as MockReacher, patch("os.makedirs"):
+            mock_instance = Mock()
+            mock_instance.program_running = False
+            mock_instance.ser = Mock()
+            mock_instance.ser.is_open = False
+            mock_instance.get_firmware_information.return_value = {}
+            mock_instance.get_behavior_data.return_value = []
+            mock_instance.get_frame_data.return_value = []
+            mock_instance.get_frame_timestamps_count.return_value = 0
+            mock_instance.get_hardware_settings.return_value = []
+            mock_instance.get_program_running.return_value = False
+            mock_instance.get_filename.return_value = None
+            mock_instance.get_data_destination.return_value = None
+            mock_instance.get_detected_paradigm.return_value = None
+            mock_instance.make_destination_folder.return_value = "/tmp/reacher_test"
+            MockReacher.return_value = mock_instance
+            app = create_app()
+            with TestClient(app) as c:
+                yield c
+
+    def _create_session(self, api_client):
+        resp = api_client.post("/api/sessions", json={"port": "/dev/ttyUSB0"}, headers=AUTH_HEADER)
+        return resp.json()["session_id"]
+
+    def test_running_state_sent_on_connect(self, api_client):
+        """A session promoted to 'running' before the WS connects still reports
+        'running' as the first message — the core of the proxy late-connect fix."""
+        sid = self._create_session(api_client)
+        api_client.app.state.session_manager.set_state(sid, "running")
+
+        with api_client.websocket_connect(f"/ws/{sid}?token={API_KEY}") as wsconn:
+            msg = json.loads(wsconn.receive_text())
+
+        assert msg["type"] == "session_state"
+        assert msg["session_id"] == sid
+        assert msg["data"]["state"] == "running"
+
+    def test_idle_default_state_sent_on_connect(self, api_client):
+        """A freshly created session reports its 'idle' default on connect."""
+        sid = self._create_session(api_client)
+
+        with api_client.websocket_connect(f"/ws/{sid}?token={API_KEY}") as wsconn:
+            msg = json.loads(wsconn.receive_text())
+
+        assert msg["type"] == "session_state"
+        assert msg["data"]["state"] == "idle"


### PR DESCRIPTION
## Summary
Root-cause backend fix for **Otis-Lab-MUSC/labrynth#15** — proxy/IoT-mode remote sessions receiving zero Arduino events.

## Root cause
In proxy mode the browser session is created **only on the Pi** (session creation is proxied), so the session id is consistent and there is *no* id mismatch. The real defect is a **state-sync race**:

1. The WS relay opens upstream to the Pi only **after** an async ws-token fetch — lagging the user's upload → connect → start flow.
2. The Pi broadcasts each `session_state` transition (`idle → connected → running`) as it happens. At those moments `_connections[session_id]` on the Pi is still empty (relay not yet connected), so `_broadcast_worker` fans them to **zero subscribers** and they are silently dropped.
3. When the relay finally connects and the first behavioral `event` arrives, the browser session is still `"idle"`, so the frontend `pushEvent` gate drops every event. Counters stay at zero.

The two prior fixes (`a74652e` relay error surfacing, labrynth `798aec462` reconnect counter) never touched this window, which is why the bug persisted.

## Change
- **`websocket.py`** — on WS connect, after the client is registered, replay the **current** `session_state` to just that socket (via `app.state.session_manager`). A late-connecting relay, a direct browser, or any reconnect now immediately learns the real state. Reuses the existing `session_state` message contract the frontend already handles.
- **`proxy.py`** — pass `ping_interval=None` to the relay's upstream `websockets.connect` so the library ping can't race uvicorn's server-side keepalive and silently tear down the upstream under load (secondary hardening).
- A `logger.debug` fanout line records subscriber count (gated behind DEBUG) to confirm zero-subscriber drops during the start sequence.

## Tests
- New `TestSessionStateSnapshotOnConnect`: a client connecting to `/ws/{sid}` receives the current `session_state` (`running` or `idle`) as its first message.
- `pytest`: **245 passed**. The 2 failures in `tests/test_commands.py` (PAV command 212 / deprecated-command parity) are **pre-existing on `main`** (confirmed with this branch stashed) and unrelated to this change.

## Release sequencing
This is the root fix; the labrynth frontend PR adds defense-in-depth. After merge, cut a reacher release (`scripts/bump-version.py` → tag → PyPI) and bump labrynth's `reacher>=` pin.

Refs Otis-Lab-MUSC/labrynth#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)