### PR TITLE
chore: rebrand umbrella REACHER Suite to Phoxel Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Python](https://img.shields.io/badge/python-3.10%E2%80%933.13-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)
-[![REACHER Suite](https://img.shields.io/badge/REACHER_Suite-member-orange)](https://github.com/Otis-Lab-MUSC)
+[![Phoxel Workbench](https://img.shields.io/badge/Phoxel_Workbench-member-orange)](https://github.com/Otis-Lab-MUSC)
 
 *Written by*: Joshua Boquiren
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -94,8 +94,8 @@ brew install avrdude
 Download or clone the REACHER repository:
 
 ```
-git clone https://github.com/Otis-Lab-MUSC/REACHER-Suite.git
-cd REACHER-Suite/reacher
+git clone https://github.com/thejoshbq/phoxel-workbench.git
+cd phoxel-workbench/reacher
 ```
 
 If you don't have `git`, you can download the repository as a ZIP file from GitHub and extract it.
@@ -487,7 +487,7 @@ On Windows, `~` refers to `C:\Users\YourUsername`.
 A virtual environment keeps REACHER's dependencies separate from the rest of your system. This is recommended on systems with "externally managed" Python (Ubuntu 23.04+, Fedora 38+, Raspberry Pi OS Bookworm+).
 
 ```
-cd REACHER-Suite/reacher
+cd phoxel-workbench/reacher
 
 # Create the virtual environment
 python3 -m venv .venv
@@ -506,7 +506,7 @@ reacher
 When using a virtual environment with systemd, update the service file's `ExecStart` to use the full path to the venv's binary:
 
 ```
-ExecStart=/path/to/REACHER-Suite/reacher/.venv/bin/reacher
+ExecStart=/path/to/phoxel-workbench/reacher/.venv/bin/reacher
 ```
 
 ---

--- a/firmware/CLAUDE.md
+++ b/firmware/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Operant-conditioning firmware for Arduino Mega 2560 (ATmega2560, 8 KB RAM, 256 KB flash). Five sketches share one C++ library and produce five `.hex` files consumed by the REACHER backend.
 
-This `firmware/` tree lives inside the `reacher` repo (folded in from the now-archived `Otis-Lab-MUSC/reacher-firmware`). `compile.sh` writes hex artifacts up into the backend package-data directory `../src/reacher/hex/<board>/`, which is committed and shipped in the `reacher` wheel. For the wider Suite (paradigm names, command-code ranges, event levels, serial framing), see `../../CLAUDE.md` (workspace) and `../CLAUDE.md` (backend). The README.md here is the canonical reference for hardware pinout, paradigm semantics, command-code list, and Pavlovian parameters — read it before authoring any sketch-level changes.
+This `firmware/` tree lives inside the `reacher` repo (folded in from the now-archived `Otis-Lab-MUSC/reacher-firmware`). `compile.sh` writes hex artifacts up into the backend package-data directory `../src/reacher/hex/<board>/`, which is committed and shipped in the `reacher` wheel. For the wider Workbench (paradigm names, command-code ranges, event levels, serial framing), see `../../CLAUDE.md` (workspace) and `../CLAUDE.md` (backend). The README.md here is the canonical reference for hardware pinout, paradigm semantics, command-code list, and Pavlovian parameters — read it before authoring any sketch-level changes.
 
 ## Commands
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -8,7 +8,7 @@
 [![Platform](https://img.shields.io/badge/platform-Arduino%20Mega%202560-teal)](https://www.arduino.cc/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)
-[![REACHER Suite](https://img.shields.io/badge/REACHER_Suite-member-orange)](https://github.com/Otis-Lab-MUSC)
+[![Phoxel Workbench](https://img.shields.io/badge/Phoxel_Workbench-member-orange)](https://github.com/Otis-Lab-MUSC)
 
 *Written by*: Joshua Boquiren
 


### PR DESCRIPTION
Closes #19.

Rebrands the umbrella "REACHER Suite" → "Phoxel Workbench" in this repo. Umbrella references only — this repo's name, package, and code are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)