### PR TITLE
bug: command registry CI failures — hidden PAV params and stale LASER_SET_TRACE assertion

### DIFF
--- a/src/reacher/kernel/commands.py
+++ b/src/reacher/kernel/commands.py
@@ -268,7 +268,6 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         "Enable/disable counterbalancing",
         payload_key="enabled", payload_type="bool",
         paradigms=["pavlovian"],
-        deprecated=True,
     ),
     213: CommandSpec(
         CommandCode.PAV_CUE_DURATION, "PAV_CUE_DURATION",
@@ -287,7 +286,6 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         "Consumption window duration (ms)",
         payload_key="duration", payload_type="int",
         paradigms=["pavlovian"],
-        deprecated=True,
     ),
     216: CommandSpec(
         CommandCode.PAV_ITI_MEAN, "PAV_ITI_MEAN",
@@ -312,7 +310,6 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         "Pulse configuration for Pavlovian paradigm",
         payload_key="config", payload_type="int",
         paradigms=["pavlovian"],
-        deprecated=True,
     ),
     220: CommandSpec(
         CommandCode.SET_TRACE_INTERVAL, "SET_TRACE_INTERVAL",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -64,6 +64,23 @@ class TestGetCommandsForParadigm:
         for code in range(206, 220):
             assert code in cmds, f"PAV command {code} missing for pavlovian"
 
+    def test_reenabled_pav_params_surface_with_contract(self):
+        """212/215/219 were un-deprecated (commit aa10c70) so the frontend can
+        surface them; assert they are live and carry the payload contract the
+        labrynth Pavlovian panel branches on (bool vs int)."""
+        cmds = get_commands_for_paradigm("pavlovian")
+        expected = {
+            212: ("enabled", "bool"),
+            215: ("duration", "int"),
+            219: ("config", "int"),
+        }
+        for code, (payload_key, payload_type) in expected.items():
+            assert code in cmds, f"re-enabled PAV command {code} missing for pavlovian"
+            spec = cmds[code]
+            assert not spec.deprecated, f"{spec.name} must not be deprecated"
+            assert spec.payload_key == payload_key, f"{spec.name} payload_key drift"
+            assert spec.payload_type == payload_type, f"{spec.name} payload_type drift"
+
     def test_pavlovian_includes_laser(self):
         """Pavlovian paradigm includes base laser commands and pav-specific codes."""
         cmds = get_commands_for_paradigm("pavlovian")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -45,7 +45,6 @@ class TestCommandRegistry:
         deprecated_names = {s.name for s in deprecated}
         assert "CUE_SET_TRACE" in deprecated_names
         assert "PUMP_SET_TRACE" in deprecated_names
-        assert "LASER_SET_TRACE" in deprecated_names
 
     def test_laser_included_in_pavlovian(self):
         """Base laser commands (arm, disarm, test, freq, dur, mode) include pavlovian."""


### PR DESCRIPTION
## Intent
Fix two unrelated defects in the serial command registry that surfaced as CI failures in `tests/test_commands.py` (`test_deprecated_commands_marked` and `test_pavlovian_includes_pav_params`).

## Approach the AI took
Two atomic commits:
- **fix(commands):** Remove `deprecated=True` from PAV_COUNTERBALANCE (212), PAV_CONSUMPTION (215), and PAV_PULSE_CONFIG (219) in COMMAND_REGISTRY. These were hidden from `get_commands_for_paradigm("pavlovian")` despite the firmware implementing all three as live parameters — firmware is the source of truth, so Python now matches it. The three controls are surfaced to the frontend again.
- **test(commands):** Drop the stale `assert "LASER_SET_TRACE" in deprecated_names`. That command was removed in d274d18 and its old code 673 is now reused by LASER_SET_ONSET_DELAY, so it cannot return. CUE_SET_TRACE/PUMP_SET_TRACE assertions remain.

No enum, code, or firmware changes — only the `deprecated` flag and a test line.

## Risk
Surfacing 212/215/219 changes what `get_commands_for_paradigm("pavlovian")` returns, so the labrynth frontend now receives three additional commands — UI handling tracked in labrynth#59 (no backend break; the frontend ignores unknown commands gracefully). No serial/enum/firmware change, so `test_command_parity.py` is unaffected.

## Not tested
No hardware-in-the-loop run — verification was the mocked-serial test suite only (76 tests: commands + api, plus parity, all green). The downstream labrynth UI rendering of the three params was not exercised.

Closes #21