### PR TITLE
feat(firmware): laser LH-only trigger, lever-filter routing & Pavlovian onset delay (#67, #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `LASER_TRIGGER_LH_ONLY` (685) — fire the isolated laser on LH-lever presses; mirrored into the Python `CommandCode` enum + registry ([#67](https://github.com/Otis-Lab-MUSC/labrynth/issues/67))
+
+### Changed
+- FR/PR laser routing now uses a configurable `LASER_LEVER_FILTER` (RH or LH) instead of a hardcoded RH source; `LASER_SET_ONSET_DELAY` (673) reconfigures the chain unconditionally so the onset applies in contingent mode too; onset-delay clamp raised to 600000 ms to match cue/pump ([#67](https://github.com/Otis-Lab-MUSC/labrynth/issues/67))
+- Pavlovian scheduler honors the laser onset delay at the REWARD and CUE activation sites, clamped to the active phase window so onset can't bleed into a later phase/trial ([#69](https://github.com/Otis-Lab-MUSC/labrynth/issues/69))
+
+### Fixed
+- `pavlovian.ino` now handles `LASER_SET_ONSET_DELAY` (673) instead of returning a `006` "command not found" ([#69](https://github.com/Otis-Lab-MUSC/labrynth/issues/69))
+
 ---
 
 ## [3.0.0-beta.5] - 2026-06-17

--- a/firmware/fr/fr.ino
+++ b/firmware/fr/fr.ino
@@ -33,6 +33,7 @@ uint32_t PUMP_DURATION      = DEFAULT_PUMP_DURATION;
 uint8_t  LASER_FREQUENCY    = DEFAULT_LASER_FREQUENCY;
 uint32_t LASER_DURATION     = DEFAULT_LASER_DURATION;
 bool     LASER_RH_ONLY_MODE = false;
+DeviceType LASER_LEVER_FILTER = DeviceType::LEVER_RH;  // Lever isolating the laser in RH/LH-only mode (#67)
 uint32_t TIMEOUT_INTERVAL   = DEFAULT_TIMEOUT_INTERVAL;
 uint32_t TRACE_INTERVAL     = 0;
 
@@ -159,7 +160,7 @@ void ReconfigureChain() {
       uint32_t pd = (activePump == &pump2) ? PUMP2_ONSET_DELAY : PUMP_ONSET_DELAY;
       c0->steps[0].offsetMs += CUE_ONSET_DELAY;
       c0->steps[1].offsetMs += CUE_ONSET_DELAY + pd;
-      c0->steps[2].offsetMs += CUE_ONSET_DELAY;
+      c0->steps[2].offsetMs += CUE_ONSET_DELAY + laser.OnsetDelay();
     }
   }
   if (LASER_RH_ONLY_MODE) {
@@ -174,7 +175,7 @@ void ReconfigureChain() {
       t1->initialThreshold = 1;
       t1->pressCount = 0;
       t1->prStep = 0;
-      t1->sourceFilter = DeviceType::LEVER_RH;
+      t1->sourceFilter = LASER_LEVER_FILTER;
       t1->probability = 100;
     }
     Chain* c1 = scheduler.GetChain(1);
@@ -275,15 +276,16 @@ void ParseCommands() {
           case Cmd::CUE2_SET_ONSET_DELAY:
           case Cmd::PUMP_SET_ONSET_DELAY:
           case Cmd::PUMP2_SET_ONSET_DELAY: {
-            uint32_t d = (uint32_t)inputJson["delay"]; if (d > 60000) d = 60000;
-            if      (command == Cmd::LASER_SET_ONSET_DELAY) { laser.SetOnsetDelay(d); if (LASER_RH_ONLY_MODE) ReconfigureChain(); }
+            uint32_t d = (uint32_t)inputJson["delay"]; if (d > 600000) d = 600000;
+            if      (command == Cmd::LASER_SET_ONSET_DELAY) { laser.SetOnsetDelay(d); ReconfigureChain(); }
             else if (command == Cmd::CUE_SET_ONSET_DELAY)   { CUE_ONSET_DELAY = d;   ReconfigureChain(); }
             else if (command == Cmd::CUE2_SET_ONSET_DELAY)  { /* cue2 not in chain */ }
             else if (command == Cmd::PUMP_SET_ONSET_DELAY)  { PUMP_ONSET_DELAY = d;  ReconfigureChain(); }
             else                                             { PUMP2_ONSET_DELAY = d; ReconfigureChain(); }
             break;
           }
-          case Cmd::LASER_TRIGGER_RH_ONLY: LASER_RH_ONLY_MODE = true; ReconfigureChain(); break;
+          case Cmd::LASER_TRIGGER_RH_ONLY: LASER_RH_ONLY_MODE = true; LASER_LEVER_FILTER = DeviceType::LEVER_RH; ReconfigureChain(); break;
+          case Cmd::LASER_TRIGGER_LH_ONLY: LASER_RH_ONLY_MODE = true; LASER_LEVER_FILTER = DeviceType::LEVER_LH; ReconfigureChain(); break;
           // RH lever commands
           case Cmd::LEVER_RH_ARM:          rLever.ArmToggle(true); break;
           case Cmd::LEVER_RH_DISARM:       rLever.ArmToggle(false); break;

--- a/firmware/libraries/REACHERDevices/src/Commands.h
+++ b/firmware/libraries/REACHERDevices/src/Commands.h
@@ -106,6 +106,7 @@ namespace Cmd {
   constexpr int LASER_MODE_CONTINGENT  = 681;
   constexpr int LASER_MODE_INDEPENDENT = 682;
   constexpr int LASER_TRIGGER_RH_ONLY  = 684;  // RH lever press fires laser only (no cue, no pump)
+  constexpr int LASER_TRIGGER_LH_ONLY  = 685;  // LH lever press fires laser only (no cue, no pump)
 
   // Pavlovian laser trial assignment
   constexpr int PAV_LASER_CS_PLUS      = 691;  // Fire on CS+ trials only

--- a/firmware/pavlovian/PavlovianScheduler.cpp
+++ b/firmware/pavlovian/PavlovianScheduler.cpp
@@ -415,11 +415,15 @@ void PavlovianScheduler::PavTick(uint32_t now) {
           LogPavlovianEvent(F("REWARD_OMITTED"), now);
         }
 
-        // Laser activation during REWARD phase
+        // Laser activation during REWARD phase (onset delay deferred via Activate start ts, #69).
+        // Clamp delay to keep onset within the REWARD window so it can't slip into a later phase/trial.
         if (laser && laser->Armed() && laser->IsContingent() && laserPhase == LaserPhase::REWARD) {
           if (ShouldFireLaser(isCsMinus)) {
-            laser->Activate(now, laser->Duration());
-            LogDeviceActivation(DeviceType::LASER, now, now + laser->Duration());
+            uint32_t laserDelay = laser->OnsetDelay();
+            if (laserDelay >= pavConsumptionMs) laserDelay = (pavConsumptionMs > 1) ? (uint32_t)pavConsumptionMs - 1 : 0;
+            uint32_t laserStart = now + laserDelay;
+            laser->Activate(laserStart, laser->Duration());
+            LogDeviceActivation(DeviceType::LASER, laserStart, laserStart + laser->Duration());
           }
         }
 
@@ -474,11 +478,15 @@ void PavlovianScheduler::PavStartTrial(uint32_t now) {
     LogDeviceActivation(cueType, now, now + pavCueDuration);
   }
 
-  // Laser activation during CUE phase
+  // Laser activation during CUE phase (onset delay deferred via Activate start ts, #69).
+  // Clamp delay to keep onset within the CUE window so it can't slip into a later phase/trial.
   if (laser && laser->Armed() && laser->IsContingent() && laserPhase == LaserPhase::CUE) {
     if (ShouldFireLaser(isCsMinus)) {
-      laser->Activate(now, laser->Duration());
-      LogDeviceActivation(DeviceType::LASER, now, now + laser->Duration());
+      uint32_t laserDelay = laser->OnsetDelay();
+      if (laserDelay >= pavCueDuration) laserDelay = (pavCueDuration > 1) ? (uint32_t)pavCueDuration - 1 : 0;
+      uint32_t laserStart = now + laserDelay;
+      laser->Activate(laserStart, laser->Duration());
+      LogDeviceActivation(DeviceType::LASER, laserStart, laserStart + laser->Duration());
     }
   }
 

--- a/firmware/pavlovian/pavlovian.ino
+++ b/firmware/pavlovian/pavlovian.ino
@@ -324,6 +324,11 @@ void ParseCommands() {
           case Cmd::PAV_LASER_PHASE_CUE:
             scheduler.SetLaserPhase(LaserPhase::CUE);
             logParamChange(F("LASER"), F("laser_phase"), F("CUE")); break;
+          case Cmd::LASER_SET_ONSET_DELAY: {
+            uint32_t d = (uint32_t)inputJson["delay"]; if (d > 600000) d = 600000;
+            laser.SetOnsetDelay(d);
+            logParamChange(F("LASER"), F("onset_delay"), d); break;
+          }
 
           // Controller commands
           case Cmd::SESSION_START:

--- a/firmware/pr/pr.ino
+++ b/firmware/pr/pr.ino
@@ -33,6 +33,7 @@ uint32_t PUMP_DURATION      = DEFAULT_PUMP_DURATION;
 uint8_t  LASER_FREQUENCY    = DEFAULT_LASER_FREQUENCY;
 uint32_t LASER_DURATION     = DEFAULT_LASER_DURATION;
 bool     LASER_RH_ONLY_MODE = false;
+DeviceType LASER_LEVER_FILTER = DeviceType::LEVER_RH;  // Lever isolating the laser in RH/LH-only mode (#67)
 uint32_t TIMEOUT_INTERVAL   = DEFAULT_TIMEOUT_INTERVAL;
 uint32_t TRACE_INTERVAL     = 0;
 uint8_t  PR_STEP            = 1;
@@ -160,7 +161,7 @@ void ReconfigureChain() {
       uint32_t pd = (activePump == &pump2) ? PUMP2_ONSET_DELAY : PUMP_ONSET_DELAY;
       c0->steps[0].offsetMs += CUE_ONSET_DELAY;
       c0->steps[1].offsetMs += CUE_ONSET_DELAY + pd;
-      c0->steps[2].offsetMs += CUE_ONSET_DELAY;
+      c0->steps[2].offsetMs += CUE_ONSET_DELAY + laser.OnsetDelay();
     }
   }
   if (LASER_RH_ONLY_MODE) {
@@ -175,7 +176,7 @@ void ReconfigureChain() {
       t1->initialThreshold = 1;
       t1->pressCount = 0;
       t1->prStep = 0;
-      t1->sourceFilter = DeviceType::LEVER_RH;
+      t1->sourceFilter = LASER_LEVER_FILTER;
       t1->probability = 100;
     }
     Chain* c1 = scheduler.GetChain(1);
@@ -280,15 +281,16 @@ void ParseCommands() {
           case Cmd::CUE2_SET_ONSET_DELAY:
           case Cmd::PUMP_SET_ONSET_DELAY:
           case Cmd::PUMP2_SET_ONSET_DELAY: {
-            uint32_t d = (uint32_t)inputJson["delay"]; if (d > 60000) d = 60000;
-            if      (command == Cmd::LASER_SET_ONSET_DELAY) { laser.SetOnsetDelay(d); if (LASER_RH_ONLY_MODE) ReconfigureChain(); }
+            uint32_t d = (uint32_t)inputJson["delay"]; if (d > 600000) d = 600000;
+            if      (command == Cmd::LASER_SET_ONSET_DELAY) { laser.SetOnsetDelay(d); ReconfigureChain(); }
             else if (command == Cmd::CUE_SET_ONSET_DELAY)   { CUE_ONSET_DELAY = d;   ReconfigureChain(); }
             else if (command == Cmd::CUE2_SET_ONSET_DELAY)  { /* cue2 not in chain */ }
             else if (command == Cmd::PUMP_SET_ONSET_DELAY)  { PUMP_ONSET_DELAY = d;  ReconfigureChain(); }
             else                                             { PUMP2_ONSET_DELAY = d; ReconfigureChain(); }
             break;
           }
-          case Cmd::LASER_TRIGGER_RH_ONLY: LASER_RH_ONLY_MODE = true; ReconfigureChain(); break;
+          case Cmd::LASER_TRIGGER_RH_ONLY: LASER_RH_ONLY_MODE = true; LASER_LEVER_FILTER = DeviceType::LEVER_RH; ReconfigureChain(); break;
+          case Cmd::LASER_TRIGGER_LH_ONLY: LASER_RH_ONLY_MODE = true; LASER_LEVER_FILTER = DeviceType::LEVER_LH; ReconfigureChain(); break;
           // RH lever commands
           case Cmd::LEVER_RH_ARM:          rLever.ArmToggle(true); break;
           case Cmd::LEVER_RH_DISARM:       rLever.ArmToggle(false); break;

--- a/src/reacher/kernel/commands.py
+++ b/src/reacher/kernel/commands.py
@@ -102,6 +102,7 @@ class CommandCode(IntEnum):
     LASER_MODE_CONTINGENT = 681
     LASER_MODE_INDEPENDENT = 682
     LASER_TRIGGER_RH_ONLY = 684
+    LASER_TRIGGER_LH_ONLY = 685
     PAV_LASER_CS_PLUS = 691
     PAV_LASER_CS_MINUS = 692
     PAV_LASER_CS_BOTH = 693
@@ -571,6 +572,11 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
     684: CommandSpec(
         CommandCode.LASER_TRIGGER_RH_ONLY, "LASER_TRIGGER_RH_ONLY",
         "Set laser to RH-lever-only mode (fires on RH press, no cue, no pump)",
+        paradigms=["fr", "pr", "vi", "omission"],
+    ),
+    685: CommandSpec(
+        CommandCode.LASER_TRIGGER_LH_ONLY, "LASER_TRIGGER_LH_ONLY",
+        "Set laser to LH-lever-only mode (fires on LH press, no cue, no pump)",
         paradigms=["fr", "pr", "vi", "omission"],
     ),
     676: CommandSpec(


### PR DESCRIPTION
## Intent
Firmware half of #67 and #69 — the laser command surface lacked LH-only triggering and a working onset delay outside the legacy RH path, and `pavlovian.ino` had no onset-delay command at all.

## Approach the AI took
- **#67 (FR/PR):** new `LASER_TRIGGER_LH_ONLY = 685`; isolated-laser trigger now routes via a `LASER_LEVER_FILTER` (RH or LH) instead of a hardcoded `LEVER_RH`; `LASER_SET_ONSET_DELAY` (673) now calls `ReconfigureChain()` unconditionally so the in-chain laser step picks up the onset in Any/contingent mode too; delay clamp raised 60000 → 600000 to match cue/pump.
- **#69 (Pavlovian):** added the `LASER_SET_ONSET_DELAY` handler to `pavlovian.ino` (was falling to a 006 error); `PavlovianScheduler.cpp` defers laser activation by `OnsetDelay()` at both REWARD and CUE sites via the existing future-`Activate(startTs,dur)` mechanism, **clamped** to the owning phase window (`pavConsumptionMs` / `pavCueDuration`, minus 1ms) so onset can't bleed into a later phase/trial.

Pairs with frontend PR Otis-Lab-MUSC/labrynth#71.

## Risk
- `concurrency` / paradigm-timing: edits the Pavlovian scheduler tick path. Mitigated — onset uses the existing deferred-`Activate` (pin still driven by `Oscillate()`/`Await()` each tick, no immediate fire) and is clamped to the phase window; firmware-reviewer confirmed.
- Pre-existing quirk left as-is: mid-session `ReconfigureChain()` doesn't flush already-queued pending actions (affects all callers, not introduced here).
- `cross_repo`: depends on labrynth PR for the UI that emits 685/673.

## Not tested
- No hardware: all 5 sketches (fr/pr/pavlovian changed; omission/vi share Commands.h) compile clean for ATmega2560, but 685/673 ACK and actual laser onset timing are NOT bench-verified — needs a board (reacher-test serial echo).
- Coupled firmware hex not regenerated (`firmware/compile.sh`) — left for release packaging.

Refs #67, #69
