### PR TITLE
bug: Pavlovian pulse codes 374/375/384/385 declared in registry but unimplemented in firmware

### DIFF
--- a/firmware/libraries/REACHERDevices/src/Commands.h
+++ b/firmware/libraries/REACHERDevices/src/Commands.h
@@ -64,11 +64,15 @@ namespace Cmd {
   constexpr int CUE_SET_FREQUENCY    = 371;
   constexpr int CUE_SET_DURATION     = 372;
   constexpr int CUE_SET_TRACE        = 373;  // deprecated
+  constexpr int CUE_SET_PULSE_ON     = 374;  // CS+ pulse ON duration (ms); 0 = continuous
+  constexpr int CUE_SET_PULSE_OFF    = 375;  // CS+ pulse OFF duration (ms)
   constexpr int CUE_SET_PIN          = 376;
   constexpr int CUE_SET_ONSET_DELAY  = 377;  // Cue onset delay from trigger (ms); operant paradigms
   constexpr int CUE_SET_LEVER_FILTER  = 378;  // Per-device lever routing (0=any, 1=RH_only, 2=LH_only)
   constexpr int CUE2_SET_FREQUENCY   = 381;
   constexpr int CUE2_SET_DURATION    = 382;
+  constexpr int CUE2_SET_PULSE_ON    = 384;  // CS- pulse ON duration (ms); 0 = continuous
+  constexpr int CUE2_SET_PULSE_OFF   = 385;  // CS- pulse OFF duration (ms)
   constexpr int CUE2_SET_ONSET_DELAY  = 387;  // Cue2 onset delay (stored; cue2 absent from operant chains)
   constexpr int CUE2_SET_LEVER_FILTER = 388;
   constexpr int CUE2_SET_PIN         = 386;

--- a/firmware/pavlovian/pavlovian.ino
+++ b/firmware/pavlovian/pavlovian.ino
@@ -82,6 +82,14 @@ Slm         slm(PIN_SLM_TS);
 uint8_t  LASER_FREQUENCY = 40;
 uint32_t LASER_DURATION  = 5000;
 
+// Cue pulse shadow variables (CS+ = cue, CS- = cue2). pulse_on == 0 means
+// continuous (pulsing disabled). 374/375 set CS+, 384/385 set CS-; each
+// command carries only its own key, so we retain the companion value here.
+uint16_t CUE_PULSE_ON_MS   = 0;    // CS+ continuous by default
+uint16_t CUE_PULSE_OFF_MS  = 0;
+uint16_t CUE2_PULSE_ON_MS  = 200;  // CS- pulsed 200/200 by default (matches PAV_PULSE_CONFIG)
+uint16_t CUE2_PULSE_OFF_MS = 200;
+
 /// Central scheduler instance.
 PavlovianScheduler scheduler;
 
@@ -306,6 +314,30 @@ void ParseCommands() {
             logParamChange(F("CUE2"), F("pulse_on"), (uint32_t)onMs);
             logParamChange(F("CUE2"), F("pulse_off"), (uint32_t)offMs);
             break;
+          }
+
+          // Per-cue, per-direction pulse control (supersedes the CS--only 219
+          // for fine control). Each command carries one key; the companion
+          // value is held in the shadow globals. pulse_on == 0 => continuous.
+          case Cmd::CUE_SET_PULSE_ON: {
+            CUE_PULSE_ON_MS = inputJson["pulse_on"] | (uint16_t)0;
+            cue.SetPulsed(CUE_PULSE_ON_MS > 0, CUE_PULSE_ON_MS, CUE_PULSE_OFF_MS);
+            logParamChange(F("CUE"), F("pulse_on"), (uint32_t)CUE_PULSE_ON_MS); break;
+          }
+          case Cmd::CUE_SET_PULSE_OFF: {
+            CUE_PULSE_OFF_MS = inputJson["pulse_off"] | (uint16_t)0;
+            cue.SetPulsed(CUE_PULSE_ON_MS > 0, CUE_PULSE_ON_MS, CUE_PULSE_OFF_MS);
+            logParamChange(F("CUE"), F("pulse_off"), (uint32_t)CUE_PULSE_OFF_MS); break;
+          }
+          case Cmd::CUE2_SET_PULSE_ON: {
+            CUE2_PULSE_ON_MS = inputJson["pulse_on"] | (uint16_t)0;
+            cue2.SetPulsed(CUE2_PULSE_ON_MS > 0, CUE2_PULSE_ON_MS, CUE2_PULSE_OFF_MS);
+            logParamChange(F("CUE2"), F("pulse_on"), (uint32_t)CUE2_PULSE_ON_MS); break;
+          }
+          case Cmd::CUE2_SET_PULSE_OFF: {
+            CUE2_PULSE_OFF_MS = inputJson["pulse_off"] | (uint16_t)0;
+            cue2.SetPulsed(CUE2_PULSE_ON_MS > 0, CUE2_PULSE_ON_MS, CUE2_PULSE_OFF_MS);
+            logParamChange(F("CUE2"), F("pulse_off"), (uint32_t)CUE2_PULSE_OFF_MS); break;
           }
 
           // Pavlovian laser commands

--- a/tests/test_command_parity.py
+++ b/tests/test_command_parity.py
@@ -19,16 +19,12 @@ from reacher.kernel.commands import COMMAND_REGISTRY, CommandCode
 REPO_ROOT = Path(__file__).resolve().parent.parent
 COMMANDS_H = REPO_ROOT / "firmware" / "libraries" / "REACHERDevices" / "src" / "Commands.h"
 
-# Backend-only codes with no firmware handler. The Pavlovian UI sends
-# CUE_SET_PULSE_* (374/375/384/385) but no sketch parses them at present —
-# tracked as a known defect; remove entries here once firmware support lands
-# or the backend/frontend drop the commands.
-KNOWN_BACKEND_ONLY = {
-    CommandCode.CUE_SET_PULSE_ON,
-    CommandCode.CUE_SET_PULSE_OFF,
-    CommandCode.CUE2_SET_PULSE_ON,
-    CommandCode.CUE2_SET_PULSE_OFF,
-}
+# Backend-only codes with no firmware handler. Add an entry here (with
+# justification) only when a CommandCode is intentionally backend/frontend-only
+# and no sketch parses it. Empty: every CommandCode currently has a firmware
+# handler. (CUE_SET_PULSE_* 374/375/384/385 were implemented in the Pavlovian
+# sketch — see reacher #24.)
+KNOWN_BACKEND_ONLY: set[CommandCode] = set()
 
 _CONSTEXPR_RE = re.compile(r"^\s*constexpr\s+int\s+(\w+)\s*=\s*(\d+)\s*;", re.MULTILINE)
 


### PR DESCRIPTION
## Intent
Pavlovian CS+/CS- pulse command codes 374/375/384/385 were declared valid in the
backend CommandCode enum and labrynth metadata but had no firmware handler, so the
Pavlovian sketch emitted "command not found" at runtime. This implements them as real
per-cue, per-direction pulse handlers, closing the backend↔firmware contract gap that
labrynth #70 had only mitigated by stripping the codes from its presets.

## Approach the AI took
Chose contract option (a) — implement, not remove. Changes (reacher-only, 3 files):
- `firmware/.../Commands.h`: declared the four constants in the 3xx cue block
  (374/375 = CS+ on/off, 384/385 = CS- on/off).
- `firmware/pavlovian/pavlovian.ino`: added four shadow globals (CS+ defaults
  continuous 0/0; CS- defaults 200/200, matching the existing PAV_PULSE_CONFIG/219
  behavior) and four switch handlers that call `cue/cue2.SetPulsed(on>0, on, off)`.
  Each command carries one key, so the companion value is retained in the shadow
  global. 219 (PAV_PULSE_CONFIG) was intentionally left live — a test locks it as a
  supported compound command; these new codes supersede it for fine-grained control.
- `tests/test_command_parity.py`: emptied KNOWN_BACKEND_ONLY now that every
  CommandCode has a firmware handler.

## Risk
Firmware paradigm-adjacent edit (pulse timing on cue devices). The `SetPulsed` calls
take effect immediately on the live `cue`/`cue2` objects; if a pulse command arrives
mid-trial the cue's pulsing changes for the remainder of that cue activation. The CS-
default shadow (200/200) is asserted to match 219's prior behavior but that equivalence
was reasoned from code, not bench-verified on hardware. The shipped `.hex` package-data
was **not** regenerated (that is `/release`'s job) — a release must recompile before
firmware users see this.

## Not tested
No on-hardware smoke test (AC5: a live preset-driven Pavlovian session producing zero
"command not found") — needs a board via `reacher-test`. Verified only: full reacher
pytest suite (265 passed, incl. `test_command_parity`) and a clean `arduino-cli` compile
of `pavlovian.ino` for the mega target.

Closes #24
