### PR TITLE
bug: armed device with frequency 0 passes pre-flight as warning but 400s at session start

### DIFF
--- a/src/reacher/api/routers/validators.py
+++ b/src/reacher/api/routers/validators.py
@@ -156,14 +156,14 @@ def _check_hardware(req: ValidateConfigRequest) -> list[ValidationWarning]:
     # Rules 22, 24: primary cue
     if _hw(req, "primaryCue", "armed"):
         if (_hw(req, "primaryCue", "frequency") or 0) == 0:
-            warnings.append(_w("primaryCue.frequency", "Primary cue frequency is zero — no audible tone will play"))
+            warnings.append(_e("primaryCue.frequency", "Primary cue frequency cannot be zero when armed"))
         if (_hw(req, "primaryCue", "duration") or 0) == 0:
             warnings.append(_w("primaryCue.duration", "Primary cue duration is zero — tone will be instantaneous"))
 
     # Rules 23, 25: secondary cue
     if _hw(req, "secondaryCue", "armed"):
         if (_hw(req, "secondaryCue", "frequency") or 0) == 0:
-            warnings.append(_w("secondaryCue.frequency", "Secondary cue frequency is zero — no audible tone will play"))
+            warnings.append(_e("secondaryCue.frequency", "Secondary cue frequency cannot be zero when armed"))
         if (_hw(req, "secondaryCue", "duration") or 0) == 0:
             warnings.append(_w("secondaryCue.duration", "Secondary cue duration is zero — tone will be instantaneous"))
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -255,7 +255,7 @@ class TestPumpRules:
 class TestCueRules:
     def test_rule_22_primary_cue_freq_zero(self):
         req = _req(hardwareUi={**_pump_ok(), "primaryCue": {"armed": True, "frequency": 0, "duration": 500}})
-        assert _has(run_validation(req), "primaryCue.frequency", "warning")
+        assert _has(run_validation(req), "primaryCue.frequency", "error")
 
     def test_rule_24_primary_cue_duration_zero(self):
         req = _req(hardwareUi={**_pump_ok(), "primaryCue": {"armed": True, "frequency": 8000, "duration": 0}})
@@ -263,7 +263,7 @@ class TestCueRules:
 
     def test_rule_23_secondary_cue_freq_zero(self):
         req = _req(hardwareUi={**_pump_ok(), "secondaryCue": {"armed": True, "frequency": 0, "duration": 500}})
-        assert _has(run_validation(req), "secondaryCue.frequency", "warning")
+        assert _has(run_validation(req), "secondaryCue.frequency", "error")
 
     def test_rule_25_secondary_cue_duration_zero(self):
         req = _req(hardwareUi={**_pump_ok(), "secondaryCue": {"armed": True, "frequency": 4000, "duration": 0}})
@@ -271,7 +271,9 @@ class TestCueRules:
 
     def test_no_cue_warning_when_disarmed(self):
         req = _req(hardwareUi={**_pump_ok(), "primaryCue": {"armed": False, "frequency": 0, "duration": 0}})
-        assert not _has(run_validation(req), "primaryCue.frequency", "warning")
+        result = run_validation(req)
+        assert not _has(result, "primaryCue.frequency", "warning")
+        assert not _has(result, "primaryCue.frequency", "error")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Intent
An armed cue/secondaryCue with `frequency: 0` passed pre-flight validation as a non-blocking warning, then triggered a raw HTTP 400 ("frequency must be between 1 and 65535") at session start when the frequency command was emitted. The pre-flight and per-command validation layers disagreed on a 0-Hz armed device.

## Approach the AI took
Mirrored the existing armed-laser-frequency-0 branch in `_check_hardware` (`validators.py`): armed `primaryCue`/`secondaryCue` at `frequency == 0` now emit `_e()` (severity `error`) instead of `_w()` (warning), so `run_validation` returns `valid=False` and the config is blocked before any command is sent. `hardware.py` per-command range check is left unchanged (defense-in-depth). Tests updated: rule-22/23 assert `error`; the unarmed-cue negative test now asserts neither warning nor error. Full suite green (265 passed).

## Risk
Low — single-repo Python validation change mirroring an existing pattern. It turns a previously-acknowledgeable warning into a blocking error, so any custom config that relied on starting with a 0-Hz armed cue (which would have 400'd at session start anyway) is now blocked at pre-flight instead. Built-in Acquisition/Reversal presets use 12000/3000 Hz and are unaffected.

## Not tested
No hardware-in-the-loop / live firmware run. Verified via unit tests + FastAPI TestClient only (armed-0 → valid=false/error; unarmed-0 → valid/unflagged).

Closes #25