### PR TITLE
release: v3.0.0 stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 keywords = ["neuroscience", "arduino", "operant-conditioning", "experiment-control", "fastapi"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary

Promotes `reacher` from `3.0.0-beta.7` to `3.0.0` stable — the first stable release of the v3 line.

### Changes

- **`scripts/bump-version.py 3.0.0`** — stamps all 10 tracked files in one pass:
  - `pyproject.toml`: `3.0.0-beta.7` → `3.0.0`
  - `src/reacher/__init__.py`: `__version__` → `3.0.0`
  - `firmware/libraries/REACHERDevices/library.properties`: `version` → `3.0.0`
  - `firmware/{fr,pr,vi,omission,pavlovian}/*.ino`: `SendIdentification()` version strings → `3.0.0`
  - `README.md`: version badge + wheel-install example updated
- **`pyproject.toml`**: PyPI classifier promoted from `Development Status :: 4 - Beta` → `5 - Production/Stable`

### Notes

- Firmware hex recompile is a separate task (firmware source version strings are stamped; hex artifacts require `bash firmware/compile.sh` on an arduino-cli host).
- Closes labrynth issue [#28](https://github.com/Otis-Lab-MUSC/labrynth/issues/28) (Nature Protocols docs alignment — reacher side).

### Checklist
- [x] `bump-version.py --check 3.0.0` passes (all 10 files consistent)
- [x] PyPI classifier updated to Production/Stable
- [ ] Firmware hex recompile (separate task)