### PR TITLE
bug: unauthenticated GET /api/firmware/diagnostics leaks filesystem paths and directory listing

### DIFF
--- a/src/reacher/api/app.py
+++ b/src/reacher/api/app.py
@@ -276,7 +276,7 @@ def create_app() -> FastAPI:
     app.include_router(session.router, prefix="/api/sessions", tags=["sessions"], dependencies=api_deps)
     app.include_router(serial.router, prefix="/api/serial", tags=["serial"], dependencies=api_deps)
     app.include_router(firmware.router, prefix="/api/firmware", tags=["firmware"], dependencies=api_deps)
-    app.include_router(firmware.diagnostics_router, prefix="/api/firmware", tags=["firmware"])
+    app.include_router(firmware.diagnostics_router, prefix="/api/firmware", tags=["firmware"], dependencies=api_deps)
     app.include_router(hardware.router, prefix="/api/hardware", tags=["hardware"], dependencies=api_deps)
     app.include_router(program.router, prefix="/api/program", tags=["program"], dependencies=api_deps)
     app.include_router(data.router, prefix="/api/data", tags=["data"], dependencies=api_deps)

--- a/src/reacher/api/routers/firmware.py
+++ b/src/reacher/api/routers/firmware.py
@@ -19,7 +19,7 @@ from . import websocket as ws_mod
 _MAX_HEX_SIZE = 200 * 1024  # 200 KB — hex files are typically 15-40 KB
 
 router = APIRouter()
-diagnostics_router = APIRouter()  # Registered without auth in app.py
+diagnostics_router = APIRouter()
 _logger = logging.getLogger(__name__)
 _uploader = FirmwareUploader()
 

--- a/src/reacher/api/routers/lifecycle.py
+++ b/src/reacher/api/routers/lifecycle.py
@@ -5,12 +5,44 @@ import logging
 
 from fastapi import APIRouter, Response
 
-from .websocket import total_connections, _trigger_shutdown, is_suspended, had_connections
+from .websocket import (
+    total_connections,
+    _trigger_shutdown,
+    is_suspended,
+    had_connections,
+    _any_session_active,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _SHUTDOWN_GRACE_PERIOD = 30  # seconds to wait for reconnection (e.g. F5 refresh)
+
+
+async def _delayed_shutdown():
+    """Wait the grace period, then shut down only if it is safe to do so.
+
+    Module-level (not a closure) so the safety guards can be unit-tested directly,
+    mirroring the watchdog (``websocket._watchdog``).
+    """
+    await asyncio.sleep(_SHUTDOWN_GRACE_PERIOD)
+    if not had_connections():
+        logger.info("Shutdown beacon: no WS connections ever seen — ignoring (pre-serial state)")
+        return
+    if is_suspended():
+        logger.info("Shutdown beacon: server already suspended — hard-kill timer owns shutdown")
+        return
+    if _any_session_active():
+        # Mirror the watchdog guard (Fix F-001): never let the headerless,
+        # auth-free beacon kill the process while a session is recording —
+        # even if its WS client is momentarily orphaned (total_connections() == 0).
+        logger.info("Shutdown beacon: session running/paused — refusing shutdown (mid-acquisition guard)")
+        return
+    if total_connections() == 0:
+        logger.info("Grace period elapsed with 0 connections — shutting down")
+        _trigger_shutdown()
+    else:
+        logger.info("Connections re-established during grace period — shutdown cancelled")
 
 
 @router.post("/shutdown")
@@ -23,20 +55,5 @@ async def shutdown(response: Response):
     """
     logger.info("Shutdown beacon received — waiting %ds grace period", _SHUTDOWN_GRACE_PERIOD)
     response.status_code = 202
-
-    async def _delayed_shutdown():
-        await asyncio.sleep(_SHUTDOWN_GRACE_PERIOD)
-        if not had_connections():
-            logger.info("Shutdown beacon: no WS connections ever seen — ignoring (pre-serial state)")
-            return
-        if is_suspended():
-            logger.info("Shutdown beacon: server already suspended — hard-kill timer owns shutdown")
-            return
-        if total_connections() == 0:
-            logger.info("Grace period elapsed with 0 connections — shutting down")
-            _trigger_shutdown()
-        else:
-            logger.info("Connections re-established during grace period — shutdown cancelled")
-
     asyncio.get_running_loop().create_task(_delayed_shutdown())
     return {"status": "shutdown_scheduled"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,14 @@ class TestAuthEndpoints:
         resp = client.get("/health")
         assert resp.status_code == 200
 
+    def test_firmware_diagnostics_requires_auth(self, client):
+        resp = client.get("/api/firmware/diagnostics")
+        assert resp.status_code == 401
+
+    def test_firmware_diagnostics_auth_ok(self, client):
+        resp = client.get("/api/firmware/diagnostics", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+
 
 class TestSessionEndpoints:
     def test_list_sessions_empty(self, client):

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,133 @@
+"""Tests for the lifecycle shutdown beacon (issue #30).
+
+The ``POST /api/lifecycle/shutdown`` beacon is intentionally auth-free
+(``navigator.sendBeacon`` cannot set an Authorization header). These tests lock in
+the mid-acquisition guard that prevents an unauthenticated beacon from terminating
+the process while a session is recording, while preserving the legitimate idle
+tab-close path.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+from fastapi.testclient import TestClient
+from reacher.api.app import create_app
+
+import reacher.api.routers.lifecycle as lifecycle
+import reacher.api.routers.websocket as ws
+
+
+@pytest.fixture(autouse=True)
+def reset_ws_globals():
+    """Save and restore websocket module globals between tests.
+
+    Mirrors the fixture in test_websocket.py so this file stays isolation-safe as it
+    grows, even though the current tests only read a subset of these globals.
+    """
+    saved = (
+        ws._had_connections,
+        ws._last_connection_time,
+        ws._dropped_events,
+        ws._app_ref,
+        ws._shutdown_scheduled,
+        ws._server_suspended,
+        ws._session_orphaned,
+    )
+    yield
+    ws._connections.clear()
+    ws._had_connections = saved[0]
+    ws._last_connection_time = saved[1]
+    with ws._dropped_events_lock:
+        ws._dropped_events = saved[2]
+    ws._app_ref = saved[3]
+    ws._shutdown_scheduled = saved[4]
+    ws._server_suspended = saved[5]
+    ws._session_orphaned = saved[6]
+
+
+def _app_ref_with_session(state):
+    """Build a mock app_ref whose session manager holds one session in ``state``."""
+    mock_session = Mock()
+    mock_session.state = state
+    mock_sm = Mock()
+    mock_sm._sessions = {"sess1": mock_session}
+    mock_app = Mock()
+    mock_app.state.session_manager = mock_sm
+    return mock_app
+
+
+class TestBeaconShutdownGuard:
+    """Issue #30: beacon must not kill the process mid-acquisition."""
+
+    @pytest.mark.parametrize("state", ["running", "paused"])
+    async def test_refuses_shutdown_while_session_active(self, state):
+        # Beacon's preconditions met (a client connected then dropped), 0 connections,
+        # but a session is recording/paused — the orphaned-but-active attack path.
+        ws._had_connections = True
+        ws._server_suspended = False
+        ws._connections.clear()  # total_connections() == 0
+        ws._app_ref = _app_ref_with_session(state)
+
+        with patch.object(lifecycle, "_trigger_shutdown") as mock_shutdown, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            await lifecycle._delayed_shutdown()
+
+        mock_shutdown.assert_not_called()
+
+    async def test_shuts_down_when_idle(self):
+        # Legitimate idle tab-close: connections existed, none active now, no session.
+        ws._had_connections = True
+        ws._server_suspended = False
+        ws._connections.clear()
+        ws._app_ref = _app_ref_with_session("stopped")
+
+        with patch.object(lifecycle, "_trigger_shutdown") as mock_shutdown, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            await lifecycle._delayed_shutdown()
+
+        mock_shutdown.assert_called_once()
+
+    async def test_no_shutdown_when_never_connected(self):
+        # Pre-serial state: no WS client ever connected → beacon is ignored.
+        ws._had_connections = False
+        ws._server_suspended = False
+        ws._connections.clear()
+        ws._app_ref = _app_ref_with_session("idle")
+
+        with patch.object(lifecycle, "_trigger_shutdown") as mock_shutdown, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            await lifecycle._delayed_shutdown()
+
+        mock_shutdown.assert_not_called()
+
+    async def test_no_shutdown_when_connections_reestablished(self):
+        # A client reconnected during the grace period → cancel shutdown.
+        ws._had_connections = True
+        ws._server_suspended = False
+        ws._connections.clear()
+        ws._connections["sess1"].add(Mock())  # total_connections() == 1
+        ws._app_ref = _app_ref_with_session("stopped")
+
+        with patch.object(lifecycle, "_trigger_shutdown") as mock_shutdown, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            await lifecycle._delayed_shutdown()
+
+        mock_shutdown.assert_not_called()
+
+
+class TestBeaconEndpoint:
+    """The endpoint stays auth-free and accepts the headerless beacon."""
+
+    def test_shutdown_endpoint_no_auth_required(self):
+        with patch("reacher.session_manager.REACHER"), patch("os.makedirs"):
+            app = create_app()
+            # Stub the delayed task so the test doesn't wait the real grace period;
+            # AsyncMock() returns an awaitable, satisfying create_task().
+            with patch.object(lifecycle, "_delayed_shutdown", new_callable=AsyncMock) as mock_delayed:
+                with TestClient(app) as client:
+                    # No Authorization header, no body — the sendBeacon contract.
+                    resp = client.post("/api/lifecycle/shutdown")
+
+        # Auth-free: accepted (202), not rejected (401).
+        assert resp.status_code == 202
+        assert resp.json() == {"status": "shutdown_scheduled"}
+        mock_delayed.assert_called_once()


### PR DESCRIPTION
## Intent
`GET /api/firmware/diagnostics` was mounted without authentication, returning absolute filesystem paths, directory listings, and environment details to any caller. On a `0.0.0.0`-bound instance this enables unauthenticated reconnaissance inconsistent with the rest of `/api/*`.

## Approach the AI took
- `app.py`: added `dependencies=api_deps` to the `diagnostics_router` registration so the endpoint now requires a Bearer key.
- `firmware.py`: no structural change — auth is enforced at the router level.
- `lifecycle.py`: extracted `_delayed_shutdown()` from a closure to a module-level function; the shutdown beacon stays auth-free (required for `navigator.sendBeacon`) but now guards against mid-acquisition termination (checks no active session, no suspension, connections present).
- Tests (`test_api.py`, new `test_lifecycle.py`): cover both the auth gate and the shutdown guard conditions.

> Note: branch also contains `fix(api): guard lifecycle shutdown beacon (#30)` — that commit will merge as part of this PR.

## Risk
FILL IN: <what could go wrong or break>

## Not tested
FILL IN: <what was not covered by testing>

Closes #32