### PR TITLE
fix(kernel): surface log-write failures as throttled WS warnings

### DIFF
--- a/src/reacher/kernel/reacher.py
+++ b/src/reacher/kernel/reacher.py
@@ -124,6 +124,12 @@ class REACHER:
         self._queue_overflow_count: int = 0
         self._last_queue_overflow_emit: float = float("-inf")
 
+        # Fix: #33 — Surface log-write failures to the operator via WS warning.
+        # Throttle per log_type (1 s) and accumulate a consecutive-failure count
+        # so a ENOSPC storm emits one event/sec with the run total, not one per write.
+        self._last_log_failure_emit: Dict[str, float] = {}
+        self._log_failure_counts: Dict[str, int] = {"event_log": 0, "controller_log": 0}
+
         # Fix 7.4: track cumulative event_callback failures so the API layer
         # can surface degraded WS/observer health without risking recursion
         # (a broken callback is the one channel we can't use to self-report).
@@ -891,6 +897,16 @@ class REACHER:
                 self._event_log_write_count = 0
         except Exception:
             self.logger.warning("Failed to write event log entry", exc_info=True)
+            self._log_failure_counts["event_log"] += 1
+            _now = time.monotonic()
+            if _now - self._last_log_failure_emit.get("event_log", float("-inf")) > 1.0:
+                self._last_log_failure_emit["event_log"] = _now
+                self._emit("warning", {
+                    "reason": "log_write_failure",
+                    "log_type": "event_log",
+                    "failures_since_last_emit": self._log_failure_counts["event_log"],
+                })
+                self._log_failure_counts["event_log"] = 0
 
     def _close_event_log(self) -> None:
         """Flush and close the persistent event log file handle."""
@@ -901,6 +917,7 @@ class REACHER:
                 self._event_log_file.close()
             except Exception:
                 self.logger.warning("Failed to close event log", exc_info=True)
+                self._emit("warning", {"reason": "log_close_failure", "log_type": "event_log"})
 
     def _write_controller_log(self, data: dict) -> None:
         """Append a JSON line to controller_log.json (Fix 4.9).
@@ -920,6 +937,16 @@ class REACHER:
                 self._controller_log_write_count = 0
         except Exception:
             self.logger.warning("Failed to write controller log", exc_info=True)
+            self._log_failure_counts["controller_log"] += 1
+            _now = time.monotonic()
+            if _now - self._last_log_failure_emit.get("controller_log", float("-inf")) > 1.0:
+                self._last_log_failure_emit["controller_log"] = _now
+                self._emit("warning", {
+                    "reason": "log_write_failure",
+                    "log_type": "controller_log",
+                    "failures_since_last_emit": self._log_failure_counts["controller_log"],
+                })
+                self._log_failure_counts["controller_log"] = 0
 
     def _close_controller_log(self) -> None:
         """Flush and close the persistent controller log file handle."""
@@ -930,6 +957,7 @@ class REACHER:
                 self._controller_log_file.close()
             except Exception:
                 self.logger.warning("Failed to close controller log", exc_info=True)
+                self._emit("warning", {"reason": "log_close_failure", "log_type": "controller_log"})
 
     def _export_segment(self, behavior: list, suffix: str = "") -> str:
         """Write behavior_events{suffix}.csv to the session log directory.

--- a/tests/core/test_reacher.py
+++ b/tests/core/test_reacher.py
@@ -706,6 +706,202 @@ class TestF010EventLogFsync:
         mock_close_log.assert_called_once()
 
 
+class TestIssue33LogWriteFailureSurfacing:
+    """Issue #33: kernel log-write failure surfacing — throttled WS warnings."""
+
+    def test_write_event_log_failure_emits_warning(self, reacher, mocker):
+        """Write failure increments count and emits throttled warning to WS."""
+        mock_file = Mock()
+        mock_file.closed = False
+        mock_file.fileno.return_value = 99
+        mock_file.write.side_effect = OSError("No space left on device")
+        mocker.patch("builtins.open", return_value=mock_file)
+        mocker.patch("os.fsync")
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._write_event_log({"x": 1})
+
+        assert cb.call_count == 1
+        call_args = cb.call_args[0]
+        assert call_args[0] == "sid"
+        assert call_args[1] == "warning"
+        data = call_args[2]
+        assert data["reason"] == "log_write_failure"
+        assert data["log_type"] == "event_log"
+        assert data["failures_since_last_emit"] == 1
+
+    def test_write_event_log_failure_throttled(self, reacher, mocker):
+        """Multiple write failures within 1s throttle window emit only once."""
+        mock_file = Mock()
+        mock_file.closed = False
+        mock_file.fileno.return_value = 99
+        mock_file.write.side_effect = OSError("No space left on device")
+        mocker.patch("builtins.open", return_value=mock_file)
+        mocker.patch("os.fsync")
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._write_event_log({"x": 1})
+        reacher._write_event_log({"x": 2})
+
+        assert cb.call_count == 1
+
+    def test_write_event_log_failure_resets_count_after_emit(self, reacher, mocker):
+        """Failure count resets to 0 after emit, then increments on next failure."""
+        mock_file = Mock()
+        mock_file.closed = False
+        mock_file.fileno.return_value = 99
+        mock_file.write.side_effect = OSError("No space left on device")
+        mocker.patch("builtins.open", return_value=mock_file)
+        mocker.patch("os.fsync")
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._write_event_log({"x": 1})
+        assert cb.call_count == 1
+
+        reacher._write_event_log({"x": 2})
+        assert cb.call_count == 1
+        assert reacher._log_failure_counts["event_log"] == 1
+
+    def test_write_controller_log_failure_emits_warning(self, reacher, mocker):
+        """Controller log write failure emits warning with correct log_type."""
+        mock_file = Mock()
+        mock_file.closed = False
+        mock_file.fileno.return_value = 99
+        mock_file.write.side_effect = OSError("No space left on device")
+        mocker.patch("builtins.open", return_value=mock_file)
+        mocker.patch("os.fsync")
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._write_controller_log({"x": 1})
+
+        assert cb.call_count == 1
+        call_args = cb.call_args[0]
+        assert call_args[0] == "sid"
+        assert call_args[1] == "warning"
+        data = call_args[2]
+        assert data["reason"] == "log_write_failure"
+        assert data["log_type"] == "controller_log"
+        assert data["failures_since_last_emit"] == 1
+
+    def test_close_event_log_failure_emits_warning(self, reacher, mocker):
+        """Close failure emits warning (not throttled) immediately."""
+        handle = mocker.MagicMock()
+        handle.closed = False
+        handle.flush.side_effect = OSError("disk error")
+        reacher._event_log_file = handle
+        mocker.patch("os.fsync")
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._close_event_log()
+
+        assert cb.call_count == 1
+        call_args = cb.call_args[0]
+        assert call_args[0] == "sid"
+        assert call_args[1] == "warning"
+        data = call_args[2]
+        assert data["reason"] == "log_close_failure"
+        assert data["log_type"] == "event_log"
+
+    def test_close_controller_log_failure_emits_warning(self, reacher, mocker):
+        """Controller log close failure emits warning with correct log_type."""
+        handle = mocker.MagicMock()
+        handle.closed = False
+        handle.flush.side_effect = OSError("disk error")
+        reacher._controller_log_file = handle
+        mocker.patch("os.fsync")
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._close_controller_log()
+
+        assert cb.call_count == 1
+        call_args = cb.call_args[0]
+        assert call_args[0] == "sid"
+        assert call_args[1] == "warning"
+        data = call_args[2]
+        assert data["reason"] == "log_close_failure"
+        assert data["log_type"] == "controller_log"
+
+    def test_write_event_log_failure_no_exception_escapes(self, reacher, mocker):
+        """Write failure is silently caught; broken callback increments emit_failure_count."""
+        mock_file = Mock()
+        mock_file.closed = False
+        mock_file.fileno.return_value = 99
+        mock_file.write.side_effect = OSError("No space left on device")
+        mocker.patch("builtins.open", return_value=mock_file)
+        mocker.patch("os.fsync")
+
+        cb = Mock(side_effect=Exception("Callback error"))
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        try:
+            reacher._write_event_log({"x": 1})
+        except Exception as e:
+            pytest.fail(f"Unexpected exception: {e}")
+
+        assert reacher.emit_failure_count == 1
+
+    def test_close_event_log_failure_no_emit_when_no_callback(self, reacher, mocker):
+        """Close failure with no callback is a no-op on _emit — no exception, no WS call."""
+        handle = mocker.MagicMock()
+        handle.closed = False
+        handle.flush.side_effect = OSError("disk error")
+        reacher._event_log_file = handle
+        mocker.patch("os.fsync")
+
+        reacher.event_callback = None
+
+        try:
+            reacher._close_event_log()
+        except Exception as e:
+            pytest.fail(f"Unexpected exception: {e}")
+
+        assert reacher.emit_failure_count == 0
+
+    def test_write_event_log_fsync_failure_emits_warning(self, reacher, mocker):
+        """fsync failure in write is caught and emitted as log_write_failure."""
+        mock_file = Mock()
+        mock_file.closed = False
+        mock_file.fileno.return_value = 99
+        mocker.patch("builtins.open", return_value=mock_file)
+        fsync_mock = mocker.patch("os.fsync")
+        fsync_mock.side_effect = OSError("fsync error")
+
+        reacher._EVENT_LOG_FSYNC_INTERVAL = 1
+
+        cb = Mock()
+        reacher.event_callback = cb
+        reacher.session_id = "sid"
+
+        reacher._write_event_log({"x": 1})
+
+        assert cb.call_count == 1
+        call_args = cb.call_args[0]
+        assert call_args[0] == "sid"
+        assert call_args[1] == "warning"
+        data = call_args[2]
+        assert data["reason"] == "log_write_failure"
+        assert data["log_type"] == "event_log"
+
+
 class TestFrameTimestampStopSemantics:
     """Fix FW-002: frame timestamps must be gated by program_flag, not discarded silently."""
 


### PR DESCRIPTION
Closes #33

## Summary
- `_write_event_log` and `_write_controller_log` previously swallowed all I/O exceptions silently; on disk-full or I/O fault a session could lose behavioral/frame data with no operator signal
- Add throttled `_emit("warning", {...})` in all four log-method except blocks: write methods throttle to 1 emit/sec per log type (matching the existing `_last_queue_overflow_emit` convention — `time.monotonic()`, `> 1.0`) with a cumulative `failures_since_last_emit` count; close methods emit directly (once-per-session, no flood risk)
- Payload: `{reason, log_type, failures_since_last_emit}` — no raw exception message to avoid leaking filesystem paths over a possibly-LAN WS connection
- 9 regression tests in `TestIssue33LogWriteFailureSurfacing` covering: emit on write failure, 1-second throttle, count reset, controller log mirroring, close-path failure, fsync failure, broken-callback resilience, and no-callback no-op

## Test plan
- [ ] `pytest tests/core/test_reacher.py` — 56 passed (47 existing + 9 new)
- [ ] Trigger a write failure manually (e.g. mount a read-only tmpfs over `~/REACHER/LOG/`) and confirm a `warning` WS event appears in the frontend during an active session
- [ ] Confirm a second write failure within 1 second does not produce a second WS event (throttle holds)
- [ ] Confirm `labrynth` frontend handles `warning` events with `reason: "log_write_failure"` gracefully — open a follow-up issue on `Otis-Lab-MUSC/labrynth` if a toast/alert is missing

**Scope note:** this fix makes failure *observable*, not *prevented* — `controller_log` has no in-memory mirror so write failures there remain unrecoverable; pre-session disk-space check and write retry are deferred to a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)