### PR TITLE
feat: make fr_lite a first-class paradigm, filter UNO to lite-only (#53)

### DIFF
--- a/src/reacher/kernel/commands.py
+++ b/src/reacher/kernel/commands.py
@@ -144,8 +144,12 @@ class CommandCode(IntEnum):
 
 
 # Paradigm identifiers used throughout the system
-PARADIGMS = ("fr", "pr", "vi", "omission", "pavlovian")
+PARADIGMS = ("fr", "pr", "vi", "omission", "pavlovian", "fr_lite")
 ALL_PARADIGMS = list(PARADIGMS)
+
+# Paradigms with two-photon hardware (microscope, SLM) available. "_lite"
+# paradigms run on boards (e.g. UNO) that lack that hardware entirely.
+NON_LITE_PARADIGMS = [p for p in ALL_PARADIGMS if not p.endswith("_lite")]
 
 SCHEDULE_TO_PARADIGM: Dict[str, str] = {
     "FIXED_RATIO": "fr",
@@ -204,7 +208,7 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.SET_RATIO, "SET_RATIO",
         "Set the fixed/progressive ratio",
         payload_key="ratio", payload_type="int",
-        paradigms=["fr", "pr"],
+        paradigms=["fr", "pr", "fr_lite"],
     ),
     202: CommandSpec(
         CommandCode.SET_PARADIGM, "SET_PARADIGM",
@@ -319,7 +323,7 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.SET_ACTIVE_PUMP, "SET_ACTIVE_PUMP",
         "Select which pump fires in the reward chain (pump2=false → primary, pump2=true → secondary)",
         payload_key="pump2", payload_type="bool",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
 
     # --- Cue ---
@@ -406,13 +410,13 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.CUE_SET_ONSET_DELAY, "CUE_SET_ONSET_DELAY",
         "Set primary cue onset delay from trigger (ms)",
         payload_key="delay", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     378: CommandSpec(
         CommandCode.CUE_SET_LEVER_FILTER, "CUE_SET_LEVER_FILTER",
         "Set primary cue lever routing filter (0=any, 1=RH_only, 2=LH_only)",
         payload_key="filter", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     386: CommandSpec(
         CommandCode.CUE2_SET_PIN, "CUE2_SET_PIN",
@@ -423,13 +427,13 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.CUE2_SET_ONSET_DELAY, "CUE2_SET_ONSET_DELAY",
         "Set secondary cue onset delay (stored; cue2 absent from operant chains)",
         payload_key="delay", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     388: CommandSpec(
         CommandCode.CUE2_SET_LEVER_FILTER, "CUE2_SET_LEVER_FILTER",
         "Set secondary cue lever routing filter (0=any, 1=RH_only, 2=LH_only)",
         payload_key="filter", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
 
     # --- Pump ---
@@ -482,13 +486,13 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.PUMP_SET_ONSET_DELAY, "PUMP_SET_ONSET_DELAY",
         "Set primary pump onset delay from reward-window start (ms)",
         payload_key="delay", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     478: CommandSpec(
         CommandCode.PUMP_SET_LEVER_FILTER, "PUMP_SET_LEVER_FILTER",
         "Set primary pump lever routing filter (0=any, 1=RH_only, 2=LH_only)",
         payload_key="filter", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     486: CommandSpec(
         CommandCode.PUMP2_SET_PIN, "PUMP2_SET_PIN",
@@ -499,13 +503,13 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.PUMP2_SET_ONSET_DELAY, "PUMP2_SET_ONSET_DELAY",
         "Set secondary pump onset delay from reward-window start (ms)",
         payload_key="delay", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     488: CommandSpec(
         CommandCode.PUMP2_SET_LEVER_FILTER, "PUMP2_SET_LEVER_FILTER",
         "Set secondary pump lever routing filter (0=any, 1=RH_only, 2=LH_only)",
         payload_key="filter", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
 
     # --- Lick Circuit ---
@@ -527,61 +531,61 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
     600: CommandSpec(
         CommandCode.LASER_DISARM, "LASER_DISARM",
         "Disarm optogenetic laser",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     601: CommandSpec(
         CommandCode.LASER_ARM, "LASER_ARM",
         "Arm optogenetic laser",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     603: CommandSpec(
         CommandCode.LASER_TEST, "LASER_TEST",
         "Test optogenetic laser",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     671: CommandSpec(
         CommandCode.LASER_SET_FREQUENCY, "LASER_SET_FREQUENCY",
         "Set laser frequency (Hz)",
         payload_key="frequency", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     672: CommandSpec(
         CommandCode.LASER_SET_DURATION, "LASER_SET_DURATION",
         "Set laser pulse duration (ms)",
         payload_key="duration", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     673: CommandSpec(
         CommandCode.LASER_SET_ONSET_DELAY, "LASER_SET_ONSET_DELAY",
         "Set laser onset delay (ms) from trigger onset",
         payload_key="delay", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     681: CommandSpec(
         CommandCode.LASER_MODE_CONTINGENT, "LASER_MODE_CONTINGENT",
         "Set laser to contingent mode (triggered by lever press)",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     682: CommandSpec(
         CommandCode.LASER_MODE_INDEPENDENT, "LASER_MODE_INDEPENDENT",
         "Set laser to independent mode (free-running)",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     684: CommandSpec(
         CommandCode.LASER_TRIGGER_RH_ONLY, "LASER_TRIGGER_RH_ONLY",
         "Set laser to RH-lever-only mode (fires on RH press, no cue, no pump)",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     685: CommandSpec(
         CommandCode.LASER_TRIGGER_LH_ONLY, "LASER_TRIGGER_LH_ONLY",
         "Set laser to LH-lever-only mode (fires on LH press, no cue, no pump)",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     676: CommandSpec(
         CommandCode.LASER_SET_PIN, "LASER_SET_PIN",
         "Reassign the laser PWM output pin",
         payload_key="pin", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission", "pavlovian"],
+        paradigms=["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
     ),
     691: CommandSpec(
         CommandCode.PAV_LASER_CS_PLUS, "PAV_LASER_CS_PLUS",
@@ -609,23 +613,27 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         paradigms=["pavlovian"],
     ),
 
-    # --- Microscope ---
+    # --- Microscope --- (absent on "_lite" boards — no two-photon hardware)
     900: CommandSpec(
         CommandCode.MICROSCOPE_DISARM, "MICROSCOPE_DISARM",
         "Disarm microscope sync",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     901: CommandSpec(
         CommandCode.MICROSCOPE_ARM, "MICROSCOPE_ARM",
         "Arm microscope sync",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     903: CommandSpec(
         CommandCode.MICROSCOPE_TEST, "MICROSCOPE_TEST",
         "Test microscope sync",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     976: CommandSpec(
         CommandCode.MICROSCOPE_SET_TRIG_PIN, "MICROSCOPE_SET_TRIG_PIN",
         "Reassign the microscope trigger output pin (timestamp pin is fixed)",
         payload_key="pin", payload_type="int",
+        paradigms=NON_LITE_PARADIGMS,
     ),
 
     # --- RH Lever ---
@@ -641,13 +649,13 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.LEVER_RH_SET_TIMEOUT, "LEVER_RH_SET_TIMEOUT",
         "Set right-hand lever timeout (ms)",
         payload_key="timeout", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     1075: CommandSpec(
         CommandCode.LEVER_RH_SET_RATIO, "LEVER_RH_SET_RATIO",
         "Set right-hand lever ratio",
         payload_key="ratio", payload_type="int",
-        paradigms=["fr", "pr"],
+        paradigms=["fr", "pr", "fr_lite"],
     ),
     1080: CommandSpec(
         CommandCode.LEVER_RH_SET_INACTIVE, "LEVER_RH_SET_INACTIVE",
@@ -676,13 +684,13 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         CommandCode.LEVER_LH_SET_TIMEOUT, "LEVER_LH_SET_TIMEOUT",
         "Set left-hand lever timeout (ms)",
         payload_key="timeout", payload_type="int",
-        paradigms=["fr", "pr", "vi", "omission"],
+        paradigms=["fr", "pr", "vi", "omission", "fr_lite"],
     ),
     1375: CommandSpec(
         CommandCode.LEVER_LH_SET_RATIO, "LEVER_LH_SET_RATIO",
         "Set left-hand lever ratio",
         payload_key="ratio", payload_type="int",
-        paradigms=["fr", "pr"],
+        paradigms=["fr", "pr", "fr_lite"],
     ),
     1380: CommandSpec(
         CommandCode.LEVER_LH_SET_INACTIVE, "LEVER_LH_SET_INACTIVE",
@@ -698,29 +706,34 @@ COMMAND_REGISTRY: Dict[int, CommandSpec] = {
         payload_key="pin", payload_type="int",
     ),
 
-    # --- SLM (11xx) ---
+    # --- SLM (11xx) --- (absent on "_lite" boards — no two-photon hardware)
     1100: CommandSpec(
         CommandCode.SLM_DISARM, "SLM_DISARM",
         "Disarm the SLM timestamp plugin",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     1101: CommandSpec(
         CommandCode.SLM_ARM, "SLM_ARM",
         "Arm the SLM timestamp plugin",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     1102: CommandSpec(
         CommandCode.SLM_SET_LASER_FREQUENCY, "SLM_SET_LASER_FREQUENCY",
         "Record the laser frequency (Hz) the SLM sync should correspond to (bookkeeping only)",
         payload_key="frequency", payload_type="int",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     1103: CommandSpec(
         CommandCode.SLM_SET_LASER_DURATION, "SLM_SET_LASER_DURATION",
         "Record the laser duration (ms) the SLM sync should correspond to (bookkeeping only)",
         payload_key="duration", payload_type="int",
+        paradigms=NON_LITE_PARADIGMS,
     ),
     1176: CommandSpec(
         CommandCode.SLM_SET_PIN, "SLM_SET_PIN",
         "Reassign the SLM timestamp input pin (PCINT0/PORTB group — pins 10–13 on the Mega, 8–13 on the UNO)",
         payload_key="pin", payload_type="int",
+        paradigms=NON_LITE_PARADIGMS,
     ),
 }
 

--- a/src/reacher/kernel/reacher.py
+++ b/src/reacher/kernel/reacher.py
@@ -1075,11 +1075,22 @@ class REACHER:
                     break
 
     def get_detected_paradigm(self) -> Optional[str]:
-        """Return the paradigm detected from firmware identification, or None."""
+        """Return the paradigm detected from firmware identification, or None.
+
+        "_lite" sketches (e.g. fr_lite.ino) report the same ``schedule`` as
+        their full counterpart (fr.ino both report FIXED_RATIO), so the
+        schedule alone can't distinguish them — check the ``sketch`` field too.
+        """
         schedule = self.firmware_information.get("schedule")
-        if schedule and isinstance(schedule, str):
-            return SCHEDULE_TO_PARADIGM.get(schedule)
-        return None
+        if not schedule or not isinstance(schedule, str):
+            return None
+        base = SCHEDULE_TO_PARADIGM.get(schedule)
+        if base is None:
+            return None
+        sketch = self.firmware_information.get("sketch")
+        if isinstance(sketch, str) and sketch.endswith("_lite.ino"):
+            return f"{base}_lite"
+        return base
 
     def set_limit_type(self, limit_type: str) -> None:
         """Set the type of limit for program execution.

--- a/src/reacher/kernel/simulator.py
+++ b/src/reacher/kernel/simulator.py
@@ -22,6 +22,7 @@ PARADIGM_TO_SCHEDULE = {
     "vi": "VARIABLE_INTERVAL",
     "omission": "OMISSION",
     "pavlovian": "PAVLOVIAN",
+    "fr_lite": "FIXED_RATIO",
 }
 
 SCHEDULE_TO_SKETCH = {
@@ -43,6 +44,7 @@ class FirmwareSimulator:
         self._stop_event = threading.Event()
 
         # Configuration state (updated by incoming commands)
+        self.paradigm = "fr"
         self.schedule = "FIXED_RATIO"
         self.ratio = 5
         self.pr_step = 2
@@ -162,6 +164,7 @@ class FirmwareSimulator:
             paradigm_val = cmd_data.get("paradigm")
             if isinstance(paradigm_val, str):
                 self.schedule = PARADIGM_TO_SCHEDULE.get(paradigm_val, self.schedule)
+                self.paradigm = paradigm_val
         elif cmd == 203:
             self.omission_interval = cmd_data.get("interval", self.omission_interval)
         elif cmd == 204:
@@ -231,7 +234,13 @@ class FirmwareSimulator:
             self.pav_iti_max = cmd_data.get("iti_max", self.pav_iti_max)
 
     def _send_identification(self):
-        sketch = SCHEDULE_TO_SKETCH.get(self.schedule, "fr.ino")
+        # "_lite" paradigms share a schedule with their full counterpart
+        # (fr_lite and fr both report FIXED_RATIO), so the sketch name has
+        # to come from the paradigm itself, not the schedule, to be accurate.
+        if self.paradigm.endswith("_lite"):
+            sketch = f"{self.paradigm}.ino"
+        else:
+            sketch = SCHEDULE_TO_SKETCH.get(self.schedule, "fr.ino")
         self._send({
             "level": "000", "device": "CONTROLLER", "sketch": sketch,
             "version": "v2.0.0-sim", "baud_rate": 115200,

--- a/src/reacher/uploader/uploader.py
+++ b/src/reacher/uploader/uploader.py
@@ -240,7 +240,15 @@ class FirmwareUploader:
         )
 
     def list_available(self, board: str = DEFAULT_BOARD) -> List[str]:
-        """Return paradigms whose hex files are present on disk for *board*."""
+        """Return paradigms whose hex files are present on disk for *board*.
+
+        UNO-class boards only ever offer "_lite" paradigms — their reduced
+        SRAM/pin count can't run the full sketches, whose hex files are kept
+        on disk under ``hex/uno/`` only for backwards compatibility (manual
+        flashing, diagnostics). This filter is declarative rather than
+        relying on those legacy files being absent, so it can't silently
+        regress if one is ever re-added.
+        """
         available = []
         for p in PARADIGMS:
             try:
@@ -248,6 +256,8 @@ class FirmwareUploader:
                 available.append(p)
             except (FileNotFoundError, ValueError):
                 pass
+        if board.lower() == "uno":
+            available = [p for p in available if p.endswith("_lite")]
         return available
 
     @staticmethod

--- a/tests/core/test_reacher.py
+++ b/tests/core/test_reacher.py
@@ -544,6 +544,22 @@ def test_get_detected_paradigm(reacher):
     assert reacher.get_detected_paradigm() == "fr"
 
 
+def test_get_detected_paradigm_lite_sketch(reacher):
+    """fr_lite reports the same schedule as fr — only the sketch name distinguishes it."""
+    reacher.firmware_information = {
+        "schedule": "FIXED_RATIO", "device": "CONTROLLER", "sketch": "fr_lite.ino",
+    }
+    assert reacher.get_detected_paradigm() == "fr_lite"
+
+
+def test_get_detected_paradigm_full_sketch_unaffected(reacher):
+    """A full (non-lite) sketch name still resolves to the bare paradigm."""
+    reacher.firmware_information = {
+        "schedule": "FIXED_RATIO", "device": "CONTROLLER", "sketch": "fr.ino",
+    }
+    assert reacher.get_detected_paradigm() == "fr"
+
+
 # ===== New tests for security & reliability audit fixes =====
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -120,6 +120,48 @@ class TestGetCommandsForParadigm:
             assert 1374 in cmds, f"LEVER_LH_SET_TIMEOUT must be available for {paradigm}"
 
 
+class TestFrLiteParadigm:
+    """fr_lite behaves exactly like fr, minus two-photon hardware (microscope, SLM)."""
+
+    def test_fr_lite_is_a_known_paradigm(self):
+        assert "fr_lite" in PARADIGMS
+
+    def test_microscope_excluded(self):
+        cmds = get_commands_for_paradigm("fr_lite")
+        for code in [900, 901, 903, 976]:
+            assert code not in cmds, f"Microscope code {code} must not be available for fr_lite"
+
+    def test_slm_excluded(self):
+        cmds = get_commands_for_paradigm("fr_lite")
+        for code in [1100, 1101, 1102, 1103, 1176]:
+            assert code not in cmds, f"SLM code {code} must not be available for fr_lite"
+
+    def test_ratio_included(self):
+        cmds = get_commands_for_paradigm("fr_lite")
+        for code in [201, 1075, 1375]:
+            assert code in cmds, f"Ratio code {code} must be available for fr_lite"
+
+    def test_laser_included(self):
+        cmds = get_commands_for_paradigm("fr_lite")
+        for code in [600, 601, 603, 671, 672, 673, 676, 681, 682, 684, 685]:
+            assert code in cmds, f"Laser code {code} must be available for fr_lite"
+
+    def test_general_devices_included(self):
+        cmds = get_commands_for_paradigm("fr_lite")
+        for code in [300, 301, 400, 401, 500, 501, 1000, 1001, 1300, 1301]:
+            assert code in cmds, f"General device code {code} must be available for fr_lite"
+
+    def test_pavlovian_only_excluded(self):
+        cmds = get_commands_for_paradigm("fr_lite")
+        for code in [206, 207, 691, 692]:
+            assert code not in cmds, f"Pavlovian-only code {code} must not be available for fr_lite"
+
+    def test_microscope_still_available_for_full_fr(self):
+        cmds = get_commands_for_paradigm("fr")
+        for code in [900, 901, 903, 976, 1100, 1101]:
+            assert code in cmds, f"Code {code} must still be available for full fr paradigm"
+
+
 class TestBuildCommandPayload:
     def test_simple_command(self):
         payload = build_command_payload(101)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,37 @@
+"""Tests for FirmwareUploader.list_available() board-aware paradigm filtering."""
+
+from reacher.uploader.uploader import FirmwareUploader
+
+
+def _make_hex_dir(tmp_path, board_hexes: dict[str, list[str]]) -> str:
+    for board, paradigms in board_hexes.items():
+        board_dir = tmp_path / board
+        board_dir.mkdir(parents=True, exist_ok=True)
+        for paradigm in paradigms:
+            (board_dir / f"{paradigm}.hex").write_bytes(b":00000001FF\n")
+    return str(tmp_path)
+
+
+def test_uno_only_lists_lite_paradigms(tmp_path):
+    """Even if legacy full-paradigm hex files are still on disk for uno,
+    only "_lite" paradigms are ever offered for that board."""
+    hex_dir = _make_hex_dir(tmp_path, {
+        "uno": ["fr", "pr", "vi", "omission", "pavlovian", "fr_lite"],
+    })
+    uploader = FirmwareUploader(hex_dir=hex_dir)
+    assert uploader.list_available("uno") == ["fr_lite"]
+
+
+def test_mega_lists_whatever_hex_exists(tmp_path):
+    """Mega has no lite/normal restriction — it offers whatever hex is present."""
+    hex_dir = _make_hex_dir(tmp_path, {
+        "mega": ["fr", "pr"],
+    })
+    uploader = FirmwareUploader(hex_dir=hex_dir)
+    assert uploader.list_available("mega") == ["fr", "pr"]
+
+
+def test_uno_with_only_lite_hex_present(tmp_path):
+    hex_dir = _make_hex_dir(tmp_path, {"uno": ["fr_lite"]})
+    uploader = FirmwareUploader(hex_dir=hex_dir)
+    assert uploader.list_available("uno") == ["fr_lite"]


### PR DESCRIPTION
## Summary
- Filters the UNO firmware-paradigm picker to only "_lite"-suffixed paradigms (`FirmwareUploader.list_available()`), declaratively rather than relying on legacy full-size hex files being absent from `hex/uno/`.
- Makes `fr_lite` a first-class paradigm in `kernel/commands.py`'s command registry: microscope/SLM commands explicitly exclude it (no two-photon hardware on lite boards), ~20 general fr-paradigm commands (ratio, lever timeout, cue/pump onset-delay + lever-filter, all laser commands) explicitly include it. Previously `fr_lite` sessions had every command rejected with a 400 at the dispatch gate.
- Fixes `get_detected_paradigm()` reconnect-time auto-detection to distinguish a lite-flashed board via the firmware `sketch` field, since both `fr` and `fr_lite` report the same `FIXED_RATIO` schedule.
- Adds `fr_lite` support to `simulator.py` so all of the above is testable without hardware.
- New tests: fr_lite command-registry behavior, reconnect detection, UNO paradigm-listing filter.

Closes #53. Companion frontend change: Otis-Lab-MUSC/labrynth#107 (depends on this).

## Test plan
- [x] `pytest` — 309 passed
- [x] `ruff check .` — clean
- [x] New tests cover: microscope/SLM excluded from fr_lite, ratio/laser included, pavlovian-only excluded, full fr unaffected, reconnect sketch-based detection, UNO-only-lite listing